### PR TITLE
Precision upgrade to 15 bits

### DIFF
--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -1073,7 +1073,7 @@ guard &c000
         ; the sign bit.
         result = (clampedsquare * (1<<fraction_bits)) and &fffe
 
-        ;print real, ~address, square, ~result
+        ;print real, ~address, square, ~result, (result / (1<<fraction_bits) - square) * (1<<fraction_bits) / 2, "ulp"
 
         org address
         equw result

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -1063,15 +1063,14 @@ guard &c000
 	address = (extended and &fffe) eor &8000
 
         ; Clamp the result at MAXINT.
-        if square > (1<<integer_bits)/2
-            clampedsquare = (1<<integer_bits)/2 - 1/(1<<fraction_bits)
+	clamp = (1<<(integer_bits - 1)) - 2/(1<<fraction_bits)
+        if square > clamp
+            clampedsquare = clamp
         else
             clampedsquare = square
         endif
 
-        ; result is a square, and so is always positive! So we need to lose
-        ; the sign bit.
-        result = (clampedsquare * (1<<fraction_bits)) and &fffe
+        result = INT(clampedsquare * (1<<(fraction_bits - 1)) + 0.5) << 1
 
         ;print real, ~address, square, ~result, (result / (1<<fraction_bits) - square) * (1<<fraction_bits) / 2, "ulp"
 

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -96,8 +96,7 @@ zi = *+1
     adc 9999            ; A = low(zr^2) + low(zi^2) = low(zr^2 + zi^2) 
     sta zr2_p_zi2_lo
     lda (zr), y         ; A = high(zr^2) 
-    adc (zi), y         ; A = high(zr^2) + high(zi^2) = high(zr^2 + zi^2) 
-    and #&7f
+    adc (zi), y         ; A = high(zr^2) + high(zi^2) = high(zr^2 + zi^2)
     cmp #4 << (fraction_bits-8)
     bcs bailout
     eor #&80            ; flip sign bit for storage

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -87,12 +87,11 @@ print "zero page:", ~zp_start, "to", ~P%
 
     ; Calculate zr^2 + zi^2. 
 
-    lda zr+1
-    cmp #&40            ; -4.0 <= zr < 4.0?
-    bmi bailout         ; if not, bail
-    lda zi+1
-    cmp #&40            ; -4.0 <= zi < 4.0?
-    bmi bailout         ; if not, bail
+    lda #&3F
+    cmp zr+1            ; -4.0 <= zr < 4.0?
+    bpl bailout         ; if not, bail
+    cmp zi+1            ; -4.0 <= zi < 4.0?
+    bpl bailout         ; if not, bail
     clc
 zr = *+1
     lda 9999            ; A = low(zr^2) 

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -71,7 +71,8 @@ print "zero page:", ~zp_start, "to", ~P%
 ; Those numbers that need to be squared (zr, zi, and zr_p_zi) are
 ; stored with inverted top bits so they can be used directly as
 ; addresses, as are values passed in from outside (ci and cr).  Other
-; numbers are generally kept in their natural form.
+; numbers are generally kept in their natural form, as are results
+; from the squaring table.
 
     org &0
     guard &a0
@@ -166,7 +167,6 @@ kernel_ci_lo = *+1
     tya
 kernel_ci_hi = *+1
     adc #99
-    eor #&80
     sta zi+1
 
     dec iterations
@@ -1071,7 +1071,7 @@ guard &c000
 
         ; result is a square, and so is always positive! So we need to lose
         ; the sign bit.
-        result = ((clampedsquare * (1<<fraction_bits)) and &fffe) eor &8000
+        result = (clampedsquare * (1<<fraction_bits)) and &fffe
 
         ;print real, ~address, square, ~result
 

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -82,7 +82,17 @@ print "zero page:", ~zp_start, "to", ~P%
 
     ; Calculate zr^2 + zi^2. 
 
-    clc
+    lda zr+1
+    cmp #&60            ; zr < &6000?
+    bcc bailout
+    cmp #&c0            ; zr >= &c000?
+    bcs bailout
+    lda zi+1
+    cmp #&60            ; zr < &6000?
+    bcc bailout
+    cmp #&c0            ; zr >= &c000?
+    bcs bailout
+    ; clc               ; already clear
 zr = *+1
     lda 9999            ; A = low(zr^2) 
     tax                 
@@ -111,6 +121,10 @@ zi = *+1
 lowbyteoftable = * + 1
     equb &ad ; lda abs
     equw fixup_table
+    ;cmp #&60            ; zr < &6000?
+    ;bcc bailout
+    ;cmp #&c0            ; zr >= &c000?
+    ;bcs bailout
     sta zr_p_zi+1
 
     ; Calculate zr^2 - zi^2. 

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -893,15 +893,6 @@ temp = screenptr ; hacky temporary storage
     skip kernel_size
     copyblock kernel, kernel_end, kernel_data
 
-; Used to fixup the high byte of a number, so that it's a valid pointer to its
-; own square in the lookup table. The table runs from &4000 to &C000, and the
-; rule is that bit7 = !bit6.
-align &100 ; must be page aligned
-.fixup_table
-    for i, 0, 255
-        equb (i and &7f) or (i and &40 eor &40)<<1
-    next
-
 ; Maps logical colours (0..15) to MODE 2 left-hand-pixel values.
 align &100 ; must be page aligned
 .palette

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -100,7 +100,7 @@ zi = *+1
     adc 9999            ; A = low(zr^2) + low(zi^2) = low(zr^2 + zi^2) 
     sta zr2_p_zi2_lo
     lda (zr), y         ; A = high(zr^2) 
-    adc (zi), y         ; A = high(zr^2) + high(zi^2) = high(zr^2 + zi^2)
+    adc (zi), y         ; A = high(zr^2) + high(zi^2) = high(zr^2 + zi^2) 
     cmp #4 << (fraction_bits-8)
     bcs bailout
     sta zr2_p_zi2_hi
@@ -112,14 +112,14 @@ zi = *+1
     adc zi+0            ; A = low(zr + zi) 
     sta zr_p_zi+0
     lda zr+1            ; A = high(zr) 
-    adc zi+1            ; A = high(zr + zi) + C
+    adc zi+1            ; A = high(zr + zi) + C 
     eor #&80
 
     cmp #&40            ; -4.0 <= (zr + zi) < 4.0?
     bmi bailout         ; if not, bail
     sta zr_p_zi+1
 
-    ; Calculate zr^2 - zi^2.
+    ; Calculate zr^2 - zi^2. 
     ; We know from earlier checks that zi and zr are in range
 
     txa                 ; A = low(zr^2) 
@@ -127,7 +127,7 @@ zi = *+1
     sbc (zi)            ; A = low(zr^2 - zi^2) 
     tax
     lda (zr), y         ; A = high(zr^2) 
-    sbc (zi), y         ; A = high(zr^2 - zi^2)
+    sbc (zi), y         ; A = high(zr^2 - zi^2) 
     sta zr2_m_zi2_hi
 
     ; Calculate zr = (zr^2 - zi^2) + cr. 
@@ -153,7 +153,7 @@ zr2_p_zi2_lo = *+1
     tax
     lda (zr_p_zi), y    ; A = high((zr + zi)^2) 
 zr2_p_zi2_hi = *+1
-    sbc #99             ; A = high((zr + zi)^2 - (zr^2 + zi^2))
+    sbc #99             ; A = high((zr + zi)^2 - (zr^2 + zi^2)) 
     tay
 
     ; Calculate zi = zi' + ci. 

--- a/src/mandel.asm
+++ b/src/mandel.asm
@@ -83,16 +83,12 @@ print "zero page:", ~zp_start, "to", ~P%
     ; Calculate zr^2 + zi^2. 
 
     lda zr+1
-    cmp #&40            ; zr < &4000?
-    bcc bailout
-    cmp #&c0            ; zr >= &c000?
-    bcs bailout
+    cmp #&40            ; -4.0 <= zr < 4.0?
+    bmi bailout         ; if not, bail
     lda zi+1
-    cmp #&40            ; zi < &4000?
-    bcc bailout
-    cmp #&c0            ; zi >= &c000?
-    bcs bailout
-    ; clc               ; already clear
+    cmp #&40            ; -4.0 <= zi < 4.0?
+    bmi bailout         ; if not, bail
+    clc
 zr = *+1
     lda 9999            ; A = low(zr^2) 
     tax                 
@@ -117,13 +113,12 @@ zi = *+1
     adc zi+1            ; A = high(zr + zi) + C
     eor #&80
 
-    cmp #&40            ; (zr + zi) < &4000?
-    bcc bailout
-    cmp #&c0            ; (zr + zi) >= &c000?
-    bcs bailout
+    cmp #&40            ; -4.0 <= (zr + zi) < 4.0?
+    bmi bailout         ; if not, bail
     sta zr_p_zi+1
 
-    ; Calculate zr^2 - zi^2. 
+    ; Calculate zr^2 - zi^2.
+    ; We know from earlier checks that zi and zr are in range
 
     txa                 ; A = low(zr^2) 
     sec

--- a/src/shell.bas
+++ b/src/shell.bas
@@ -34,7 +34,7 @@ IF G%=140 THEN cr=cr-step/5: PROCbanner: IF NOT M% UNTIL TRUE: ENDPROC
 IF G%=141 THEN cr=cr+step/5: PROCbanner: IF NOT M% UNTIL TRUE: ENDPROC
 IF G%=142 THEN ci=ci+step/5: PROCbanner: IF NOT M% UNTIL TRUE: ENDPROC
 IF G%=143 THEN ci=ci-step/ 5: PROCbanner: IF NOT M% UNTIL TRUE: ENDPROC
-IF G%=43 AND scale>1 THEN scale=scale/2: UNTIL TRUE: ENDPROC
+IF G%=43 AND scale>0.5 THEN scale=scale/2: UNTIL TRUE: ENDPROC
 IF G%=45 AND scale<16 THEN scale=scale*2: UNTIL TRUE: ENDPROC
 IF G%=32 THEN M%=NOT M%: UNTIL TRUE: ENDPROC
 IF G%=13 THEN UNTIL TRUE: ENDPROC
@@ -67,7 +67,7 @@ PROCbanner
 TIME=0
 Z%!0=FNfixed(vr)
 Z%!2=FNfixed(vi)
-Z%?4=scale*2
+Z%?4=scale*4
 Z%?5=NOT M%
 Z%!6=FNfixed(cr)
 Z%!8=FNfixed(ci)
@@ -81,9 +81,7 @@ COLOUR 7: PRINT 't: COLOUR 3: PRINT "   secs"
 ENDPROC
 
 DEFFNfixed(r)
-r=(r*1024) AND &7FFE
-IF NOT (r AND &4000) THEN r=r OR &8000
-=r
+=(r*2048) AND &FFFE EOR &8000
 
 DEFPROCdrawcursor
 IF NOT M% THEN ENDPROC


### PR DESCRIPTION
I'm afraid I've gone and enhanced Bogomandel to have 15 bits of precision.  The critical insight was that over half the entries in the table of squares were identical, being cases where squaring a number overflowed the available integer size.  This meant that with a few careful range checks, I could eliminate half of the table, which gave space to make it twice as big.

The range checks come with a slight performance penalty, but the simpler fixups required to turn numbers into addresses make up for that and I think the result is fractionally faster than the 14-bit version.

This PR and #3 are independent, so either can be merged with or without the other.

I hereby release my changes under the same licence as the rest of Bogomandel as shown in the `COPYING` file.

Now I have some very silly ideas about 16 bits to try...